### PR TITLE
Mesquite: Fix warnings from cdash builds (#634)

### DIFF
--- a/src/Control/Mesquite_InstructionQueue.cpp
+++ b/src/Control/Mesquite_InstructionQueue.cpp
@@ -346,7 +346,9 @@ void InstructionQueue::run_common( MeshDomainAssoc* mesh_and_domain,
     }
     
     if (pmesh) {
-      assert(!mesh || pmesh == mesh);
+      if(mesh) { // mesh will be unused warning when asserts are dropped
+        assert(!mesh || pmesh == mesh);
+      }
       (*instr)->loop_over_mesh( pmesh, domain, settings, err ); 
     }
     else {

--- a/src/Control/Mesquite_TerminationCriterion.cpp
+++ b/src/Control/Mesquite_TerminationCriterion.cpp
@@ -1036,7 +1036,6 @@ bool TerminationCriterion::cull_vertices_global(PatchData &global_patch,
   patch.set_domain( domain );
   patch.attach_settings( settings );
 
-  const MsqVertex* global_patch_vertex_array = global_patch.get_vertex_array( err );
   Mesh::VertexHandle* global_patch_vertex_handles = global_patch.get_vertex_handles_array();
 
   int num_culled = 0;

--- a/src/Mesh/Mesquite_ParallelHelper.cpp
+++ b/src/Mesh/Mesquite_ParallelHelper.cpp
@@ -468,10 +468,10 @@ void ParallelHelperImpl::smoothing_init(MsqError& err)
   {
     printf("[%d]i%d local %d remote %d ",rank,iteration,num_vtx_partition_boundary_local,num_vtx_partition_boundary_remote);
     printf("[%d]i%d pb1 ",rank,iteration);
-    for (i=0;i<num_vertex;i++) if (vtx_in_partition_boundary[i] == 1) printf("%d,%Zu ",i,gid[i]);
+    for (i=0;i<num_vertex;i++) if (vtx_in_partition_boundary[i] == 1) printf("%d,%llu ",i,(unsigned long long)gid[i]);
     printf("\n");
     printf("[%d]i%d pb2 ",rank,iteration);
-    for (i=0;i<num_vertex;i++) if (vtx_in_partition_boundary[i] == 2) printf("%d,%Zu ",i,gid[i]);
+    for (i=0;i<num_vertex;i++) if (vtx_in_partition_boundary[i] == 2) printf("%d,%llu ",i,(unsigned long long)gid[i]);
     printf("\n");
     fflush(NULL);
   }
@@ -1412,7 +1412,7 @@ int ParallelHelperImpl::comm_smoothed_vtx_tnb(MsqError& err)
 	part_smoothed_flag[local_id] = 1;
       }
       else {
-	printf("[%d]i%d vertex with gid %Zu and pid %d not in map\n",rank,iteration,packed_vertices_import[k][i].glob_id,neighbourProc[k]);
+	printf("[%d]i%d vertex with gid %llu and pid %d not in map\n",rank,iteration,(unsigned long long)packed_vertices_import[k][i].glob_id,neighbourProc[k]);
       }
     }
     num_neighbourProcRecv--;
@@ -1612,7 +1612,7 @@ int ParallelHelperImpl::comm_smoothed_vtx_tnb_no_all( MsqError& err )
         part_smoothed_flag[local_id] = 1;
       }
       else {
-	printf("[%d]i%d vertex with gid %Zu and pid %d not in map\n",rank,iteration,packed_vertices_import[k][i].glob_id,neighbourProc[k]);
+	printf("[%d]i%d vertex with gid %llu and pid %d not in map\n",rank,iteration,(unsigned long long)packed_vertices_import[k][i].glob_id,neighbourProc[k]);
       }
     }
     num_neighbourProcRecv--;
@@ -1822,7 +1822,7 @@ int ParallelHelperImpl::comm_smoothed_vtx_nb(MsqError& err)
 	if (0) printf("[%d]i%d updating vertex with global_id %d to %g %g %g \n", rank, iteration, (int)(packed_vertices_import[k][i].glob_id), packed_vertices_import[k][i].x, packed_vertices_import[k][i].y, packed_vertices_import[k][i].z);
       }
       else {
-	printf("[%d]i%d vertex with gid %Zu and pid %d not in map\n",rank,iteration,packed_vertices_import[k][i].glob_id,neighbourProcRecv[k]);
+	printf("[%d]i%d vertex with gid %llu and pid %d not in map\n",rank,iteration,(unsigned long long)packed_vertices_import[k][i].glob_id,neighbourProcRecv[k]);
       }
     }
   }
@@ -2036,7 +2036,7 @@ int ParallelHelperImpl::comm_smoothed_vtx_nb_no_all(MsqError& err)
 	if (0) printf("[%d]i%d updating vertex with global_id %d to %g %g %g \n", rank, iteration, (int)(packed_vertices_import[k][i].glob_id), packed_vertices_import[k][i].x, packed_vertices_import[k][i].y, packed_vertices_import[k][i].z);
       }
       else {
-	printf("[%d]i%d vertex with gid %Zu and pid %d not in map\n",rank,iteration,packed_vertices_import[k][i].glob_id,neighbourProcRecv[k]);  
+	printf("[%d]i%d vertex with gid %llu and pid %d not in map\n",rank,iteration,(unsigned long long)packed_vertices_import[k][i].glob_id,neighbourProcRecv[k]);
       }
     }
   }
@@ -2136,7 +2136,7 @@ int ParallelHelperImpl::comm_smoothed_vtx_b(MsqError& err)
 
   int num;
   int proc;
-  int tag;
+  //int tag;
   int count;
   int numVtxImport = 0;
   MPI_Status status;
@@ -2156,7 +2156,7 @@ int ParallelHelperImpl::comm_smoothed_vtx_b(MsqError& err)
              &status);          /* info about the received message */
     CHECK_MPI_RZERO( rval, err );
     proc = status.MPI_SOURCE;
-    tag = status.MPI_TAG;
+    //tag = status.MPI_TAG;
     MPI_Get_count(&status, MPI_INT, &count);
 
     //    printf("[%d]i%dp%d Receiving %d vertices from proc %d/%d/%d\n",rank,iteration,pass,num,proc,tag,count); fflush(NULL);
@@ -2186,7 +2186,7 @@ int ParallelHelperImpl::comm_smoothed_vtx_b(MsqError& err)
       CHECK_MPI_RZERO( rval, err );
 
       proc = status.MPI_SOURCE;
-      tag = status.MPI_TAG;
+      //tag = status.MPI_TAG;
       MPI_Get_count(&status, MPI_DOUBLE_PRECISION, &count);
 
       if (count != 4*num) printf("[%d]i%d WARNING: expected %d vertices = %d bytes from proc %d but only got %d bytes\n",rank,iteration,num,num*4,proc,count); fflush(NULL);
@@ -2208,7 +2208,7 @@ int ParallelHelperImpl::comm_smoothed_vtx_b(MsqError& err)
 	  if (0) printf("[%d]i%d updating vertex with global_id %d to %g %g %g \n", rank,iteration, (int)(vertex_pack[i].glob_id), vertex_pack[i].x, vertex_pack[i].y, vertex_pack[i].z);
 	}
 	else {
-	  printf("[%d]i%d vertex with gid %Zu and pid %d not in map\n",rank,iteration,vertex_pack[i].glob_id,proc);
+	  printf("[%d]i%d vertex with gid %llu and pid %d not in map\n",rank,iteration,(unsigned long long)vertex_pack[i].glob_id,proc);
 	}
       }
     }
@@ -2313,7 +2313,7 @@ int ParallelHelperImpl::comm_smoothed_vtx_b_no_all(MsqError& err)
 
   int num;
   int proc;
-  int tag;
+  //int tag;
   int count;
   int numVtxImport = 0;
   MPI_Status status;
@@ -2339,7 +2339,7 @@ int ParallelHelperImpl::comm_smoothed_vtx_b_no_all(MsqError& err)
              &status);          /* info about the received message */
     CHECK_MPI_RZERO( rval, err );
     proc = status.MPI_SOURCE;
-    tag = status.MPI_TAG;
+    //tag = status.MPI_TAG;
     MPI_Get_count(&status, MPI_INT, &count);
 
     // printf("[%d]i%dp%d Receiving %d vertices from proc %d/%d/%d\n",rank,iteration,pass,num,proc,tag,count); fflush(NULL);
@@ -2369,7 +2369,7 @@ int ParallelHelperImpl::comm_smoothed_vtx_b_no_all(MsqError& err)
       CHECK_MPI_RZERO( rval, err );
 
       proc = status.MPI_SOURCE;
-      tag = status.MPI_TAG;
+      //tag = status.MPI_TAG;
       MPI_Get_count(&status, MPI_DOUBLE_PRECISION, &count);
 
       if (count != 4*num) printf("[%d]i%d WARNING: expected %d vertices = %d bytes from proc %d but only got %d bytes\n",rank,iteration,num,num*4,proc,count); fflush(NULL);
@@ -2391,7 +2391,7 @@ int ParallelHelperImpl::comm_smoothed_vtx_b_no_all(MsqError& err)
 	  if (0 && rank == 1) printf("[%d]i%d updating vertex with global_id %d to %g %g %g \n", rank,iteration, (int)(vertex_pack[i].glob_id), vertex_pack[i].x, vertex_pack[i].y, vertex_pack[i].z);
 	}
 	else {
-	  printf("[%d]i%d vertex with gid %Zu and pid %d not in map\n",rank,iteration,vertex_pack[i].glob_id,proc);
+	  printf("[%d]i%d vertex with gid %llu and pid %d not in map\n",rank,iteration,(unsigned long long)vertex_pack[i].glob_id,proc);
 	}
       }
     }

--- a/src/QualityImprover/Mesquite_VertexMover.cpp
+++ b/src/QualityImprover/Mesquite_VertexMover.cpp
@@ -751,7 +751,7 @@ double VertexMover::loop_over_mesh( ParallelMesh* mesh,
         if (one_patch) ++inner_iter;
 
           // Call optimizer - should loop on inner_crit->terminate()
-                size_t num_vert=patch.num_free_vertices();
+             //   size_t num_vert=patch.num_free_vertices();
                 //std::cout << "P[" << get_parallel_rank() << "] tmp srk VertexMover num_vert= " << num_vert << std::endl;
               
         this->optimize_vertex_positions( patch, err );

--- a/src/QualityImprover/OptSolvers/Mesquite_ConjugateGradient.cpp
+++ b/src/QualityImprover/OptSolvers/Mesquite_ConjugateGradient.cpp
@@ -92,9 +92,12 @@ ConjugateGradient::~ConjugateGradient()
 void ConjugateGradient::initialize(PatchData &pd, MsqError &err)
 {
   if (get_parallel_size())
+  {
     MSQ_DBGOUT(2) << "\nP[" << get_parallel_rank() << "] " << "o   Performing Conjugate Gradient optimization.\n";
-  else
+  }
+  else {
     MSQ_DBGOUT(2) << "\no   Performing Conjugate Gradient optimization.\n";
+  }
   pMemento=pd.create_vertices_memento(err);
 }
 

--- a/src/QualityImprover/OptSolvers/Mesquite_NonGradient.cpp
+++ b/src/QualityImprover/OptSolvers/Mesquite_NonGradient.cpp
@@ -72,8 +72,8 @@ NonGradient::NonGradient(ObjectiveFunction* of)
     mThreshold(0.0),
     mTolerance(0.0),
     mMaxNumEval(0),
-    mNonGradDebug(0),
     mUseExactPenaltyFunction(true),
+    mNonGradDebug(0),
     mScaleDiameter(0.1)
 {
   set_debugging_level(2);
@@ -95,8 +95,8 @@ NonGradient::NonGradient(ObjectiveFunction* of, MsqError &err)
     mThreshold(0.0),
     mTolerance(0.0),
     mMaxNumEval(0),
-    mNonGradDebug(0),
     mUseExactPenaltyFunction(true),
+    mNonGradDebug(0),
     mScaleDiameter(0.1)
 {
   set_debugging_level(2);
@@ -208,7 +208,6 @@ NonGradient::amotry( std::vector<double>& simplex,
                  double psum[], int ihi, double fac, PatchData &pd, MsqError &err)
 {
   int numRow = getDimension();
-  int numCol = numRow + 1;
   std::vector<double> ptry(numRow); // does this make sense?
   double fac1=(1.0-fac)/static_cast<double>(numRow);
   double fac2=fac1-fac;
@@ -255,7 +254,7 @@ void NonGradient::printPatch(const PatchData &pd, MsqError &err)
   MSQ_PRINT(3)("Number of Vertices: %d\n",(int)pd.num_nodes());
 
   std::cout << "Patch " << numNode << "  " << numVert << "  " << numSlaveVert << "  " << numCoin << std::endl;
-  MSQ_PRINT(3)("");
+  MSQ_PRINT(3)(" "); // empty "" string gives warnings
   std::cout << "Coordinate ";
   std::cout << "         " << std::endl;
   for( size_t index = 0; index < numVert; index++ )
@@ -348,8 +347,8 @@ void NonGradient::initialize_mesh_iteration(PatchData &pd, MsqError &err)
     MSQ_PRINT(3)("minimum edge length %e    maximum edge length %e\n", minEdgeLen,  maxEdgeLen);
   }
 //  setTolerance(ftol);
-  int numRow = dimension;
-  int numCol = numRow+1;  
+  unsigned int numRow = dimension;
+  unsigned int numCol = numRow+1;
   if( numRow*numCol <= simplex.max_size() )
   { 
     simplex.assign(numRow*numCol, 0.);  // guard against previous simplex value
@@ -360,9 +359,9 @@ void NonGradient::initialize_mesh_iteration(PatchData &pd, MsqError &err)
       MSQ_SETERR(err)("Only one free vertex per patch implemented", MsqError::NOT_IMPLEMENTED);
     }
     size_t index = 0;
-    for( int col = 0; col < numCol; col++ )
+    for( unsigned int col = 0; col < numCol; col++ )
     {
-      for (int row=0;row<numRow;row++)
+      for (unsigned int row=0;row<numRow;row++)
       {
         simplex[ row + col*numRow ] = coord[index][row];
         if( row == col-1 )
@@ -402,8 +401,8 @@ void NonGradient::optimize_vertex_positions(PatchData &pd,
 
   // standardization
   TerminationCriterion* term_crit=get_inner_termination_criterion();
-  int maxNumEval = getMaxNumEval();
-  double threshold = getThreshold();
+//  int maxNumEval = getMaxNumEval();
+//  double threshold = getThreshold();
 //  double ftol = getTolerance();
   int ilo = 0;  //height[ilo]<=...
   int inhi = 0; //...<=height[inhi]<=

--- a/src/QualityImprover/OptSolvers/Mesquite_NonSmoothDescent.cpp
+++ b/src/QualityImprover/OptSolvers/Mesquite_NonSmoothDescent.cpp
@@ -1014,7 +1014,7 @@ bool NonSmoothDescent::convex_hull_test(const std::vector<Vector3D>& vec, MsqErr
 {
 //    int ierr;
     bool equil = false;
-    Direction dir_done;
+    Direction dir_done = MSQ_XDIR; // can generate a warning for switch below if not set
     Status status = MSQ_CHECK_Z_COORD_DIRECTION;
     Vector3D pt1, pt2, pt3, normal;
 

--- a/src/QualityImprover/OptSolvers/Mesquite_QuasiNewton.cpp
+++ b/src/QualityImprover/OptSolvers/Mesquite_QuasiNewton.cpp
@@ -174,7 +174,7 @@ void QuasiNewton::optimize_vertex_positions( PatchData& pd, MsqError& err )
   const double tol1 = 1e-8;
   const double epsilon = 1e-10;
 
-  double norm_r; //, norm_g;
+  // double norm_r; //, norm_g;
   double alpha, beta;
   double obj, objn;
 
@@ -270,7 +270,7 @@ void QuasiNewton::optimize_vertex_positions( PatchData& pd, MsqError& err )
     v[QNVEC-1].swap( v[0] );
     
     func.update( pd, obj, v[QNVEC], mHess, err ); MSQ_ERRRTN(err);
-    norm_r = length_squared( &(v[QNVEC][0]), nn );
+    //norm_r = length_squared( &(v[QNVEC][0]), nn );
     //norm_g = sqrt(norm_r);
 
     // checks stopping criterion 

--- a/src/QualityMetric/Debug/Mesquite_CompareQM.cpp
+++ b/src/QualityMetric/Debug/Mesquite_CompareQM.cpp
@@ -349,10 +349,10 @@ void CompareQM::check_hess( size_t handle,
                             const std::vector<Matrix3D>& hess2 )
 {
   const size_t n = index_map.size();
-  const size_t N = (n + 1) * n / 2;
+  #define defN ( (n + 1) * n / 2 ) // avoid warnings when assert is not compiled
   assert(n == indices.size());
-  assert(N == hess1.size());
-  assert(N == hess2.size());
+  assert(defN == hess1.size());
+  assert(defN == hess2.size());
   
   for (size_t r = 0; r < n; ++r) {
     const size_t r2 = index_map[r];

--- a/testSuite/parallel_untangle_shape/par_hex_untangle_shape.cpp
+++ b/testSuite/parallel_untangle_shape/par_hex_untangle_shape.cpp
@@ -381,8 +381,8 @@ public:
 		}
 	      else
 		{
-		  int  msq_debug             = debug; // 1,2,3 for more debug info
-		  bool always_smooth_local   = false;
+		  //int  msq_debug             = debug; // 1,2,3 for more debug info
+		  //bool always_smooth_local   = false;
 
 		  bool do_untangle_only = false;
 		  ParShapeImprover::ParShapeImprovementWrapper siw(innerIter,0.0,gradNorm,100);


### PR DESCRIPTION
Fixes the warnings for Mesquite for cdash (#634).

One warning for barrier_violated_msg as an unused define stops
triggering after fixing the other warnings. It's not clear to my why there
is this dependency. Since the test now builds without any
warnings, I did not make any changes for barrier_violated_msg.

I tried a release build as well and tests passed, though
I noticed there is a warning for testSuite/idft_time/main.cpp
regarding an array out of bounds for Mesquite_SymMatrix3D.hpp line 96.
This was not one of the listed cdash warnings and is perhaps a
logical error in the setup of the test. That looked like something
that should be considered by someone familiar with that test.
