### PR TITLE
mesquite: resolve compiler warnings

### DIFF
--- a/src/Control/Mesquite_InstructionQueue.cpp
+++ b/src/Control/Mesquite_InstructionQueue.cpp
@@ -315,7 +315,6 @@ void InstructionQueue::run_common( MeshDomainAssoc* mesh_and_domain,
   MsqInterrupt msq_interrupt;
 #endif
 
-//   Mesh* mesh = mesh_and_domain->get_mesh();
   MeshDomain* domain = mesh_and_domain->get_domain();
 
     // Generate SIGFPE on floating point errors

--- a/src/Control/Mesquite_InstructionQueue.cpp
+++ b/src/Control/Mesquite_InstructionQueue.cpp
@@ -315,7 +315,7 @@ void InstructionQueue::run_common( MeshDomainAssoc* mesh_and_domain,
   MsqInterrupt msq_interrupt;
 #endif
 
-  Mesh* mesh = mesh_and_domain->get_mesh();
+//   Mesh* mesh = mesh_and_domain->get_mesh();
   MeshDomain* domain = mesh_and_domain->get_domain();
 
     // Generate SIGFPE on floating point errors

--- a/src/Control/Mesquite_TerminationCriterion.cpp
+++ b/src/Control/Mesquite_TerminationCriterion.cpp
@@ -1036,7 +1036,7 @@ bool TerminationCriterion::cull_vertices_global(PatchData &global_patch,
   patch.set_domain( domain );
   patch.attach_settings( settings );
 
-  const MsqVertex* global_patch_vertex_array = global_patch.get_vertex_array( err );
+//   const MsqVertex* global_patch_vertex_array = global_patch.get_vertex_array( err );
   Mesh::VertexHandle* global_patch_vertex_handles = global_patch.get_vertex_handles_array();
 
   int num_culled = 0;

--- a/src/Mesh/Mesquite_ParallelHelper.cpp
+++ b/src/Mesh/Mesquite_ParallelHelper.cpp
@@ -464,18 +464,6 @@ void ParallelHelperImpl::smoothing_init(MsqError& err)
     }
   }    
 
-  // if (0)
-  // {
-  //   printf("[%d]i%d local %d remote %d ",rank,iteration,num_vtx_partition_boundary_local,num_vtx_partition_boundary_remote);
-  //   printf("[%d]i%d pb1 ",rank,iteration);
-  //   for (i=0;i<num_vertex;i++) if (vtx_in_partition_boundary[i] == 1) printf("%d,%Zu ",i,gid[i]);
-  //   printf("\n");
-  //   printf("[%d]i%d pb2 ",rank,iteration);
-  //   for (i=0;i<num_vertex;i++) if (vtx_in_partition_boundary[i] == 2) printf("%d,%Zu ",i,gid[i]);
-  //   printf("\n");
-  //   fflush(NULL);
-  // }
-
   num_vtx_partition_boundary = num_vtx_partition_boundary_local + num_vtx_partition_boundary_remote;
 
   /********************************************************************

--- a/src/Mesh/Mesquite_ParallelHelper.cpp
+++ b/src/Mesh/Mesquite_ParallelHelper.cpp
@@ -464,17 +464,17 @@ void ParallelHelperImpl::smoothing_init(MsqError& err)
     }
   }    
 
-  if (0)
-  {
-    printf("[%d]i%d local %d remote %d ",rank,iteration,num_vtx_partition_boundary_local,num_vtx_partition_boundary_remote);
-    printf("[%d]i%d pb1 ",rank,iteration);
-    for (i=0;i<num_vertex;i++) if (vtx_in_partition_boundary[i] == 1) printf("%d,%Zu ",i,gid[i]);
-    printf("\n");
-    printf("[%d]i%d pb2 ",rank,iteration);
-    for (i=0;i<num_vertex;i++) if (vtx_in_partition_boundary[i] == 2) printf("%d,%Zu ",i,gid[i]);
-    printf("\n");
-    fflush(NULL);
-  }
+  // if (0)
+  // {
+  //   printf("[%d]i%d local %d remote %d ",rank,iteration,num_vtx_partition_boundary_local,num_vtx_partition_boundary_remote);
+  //   printf("[%d]i%d pb1 ",rank,iteration);
+  //   for (i=0;i<num_vertex;i++) if (vtx_in_partition_boundary[i] == 1) printf("%d,%Zu ",i,gid[i]);
+  //   printf("\n");
+  //   printf("[%d]i%d pb2 ",rank,iteration);
+  //   for (i=0;i<num_vertex;i++) if (vtx_in_partition_boundary[i] == 2) printf("%d,%Zu ",i,gid[i]);
+  //   printf("\n");
+  //   fflush(NULL);
+  // }
 
   num_vtx_partition_boundary = num_vtx_partition_boundary_local + num_vtx_partition_boundary_remote;
 
@@ -1412,7 +1412,10 @@ int ParallelHelperImpl::comm_smoothed_vtx_tnb(MsqError& err)
 	part_smoothed_flag[local_id] = 1;
       }
       else {
-	printf("[%d]i%d vertex with gid %Zu and pid %d not in map\n",rank,iteration,packed_vertices_import[k][i].glob_id,neighbourProc[k]);
+         std::cout << "[" << rank << "]i" << iteration
+                   << " vertex with gid " << packed_vertices_import[k][i].glob_id
+                   << " and pid " << neighbourProc[k]
+                   << " not in map" << std::endl ;
       }
     }
     num_neighbourProcRecv--;
@@ -1612,7 +1615,11 @@ int ParallelHelperImpl::comm_smoothed_vtx_tnb_no_all( MsqError& err )
         part_smoothed_flag[local_id] = 1;
       }
       else {
-	printf("[%d]i%d vertex with gid %Zu and pid %d not in map\n",rank,iteration,packed_vertices_import[k][i].glob_id,neighbourProc[k]);
+
+         std::cout << "[" << rank << "]i" << iteration
+                   << " vertex with gid " << packed_vertices_import[k][i].glob_id
+                   << " and pid " << neighbourProc[k]
+                   << " not in map" << std::endl ;
       }
     }
     num_neighbourProcRecv--;
@@ -1822,7 +1829,10 @@ int ParallelHelperImpl::comm_smoothed_vtx_nb(MsqError& err)
 	if (0) printf("[%d]i%d updating vertex with global_id %d to %g %g %g \n", rank, iteration, (int)(packed_vertices_import[k][i].glob_id), packed_vertices_import[k][i].x, packed_vertices_import[k][i].y, packed_vertices_import[k][i].z);
       }
       else {
-	printf("[%d]i%d vertex with gid %Zu and pid %d not in map\n",rank,iteration,packed_vertices_import[k][i].glob_id,neighbourProcRecv[k]);
+         std::cout << "[" << rank << "]i" << iteration
+                   << " vertex with gid " << packed_vertices_import[k][i].glob_id
+                   << " and pid " << neighbourProcRecv[k]
+                   << " not in map" << std::endl ;
       }
     }
   }
@@ -2033,10 +2043,13 @@ int ParallelHelperImpl::comm_smoothed_vtx_nb_no_all(MsqError& err)
         MSQ_ERRZERO(err);
 	assert(part_smoothed_flag[local_id] == 0);
 	part_smoothed_flag[local_id] = 1;
-	if (0) printf("[%d]i%d updating vertex with global_id %d to %g %g %g \n", rank, iteration, (int)(packed_vertices_import[k][i].glob_id), packed_vertices_import[k][i].x, packed_vertices_import[k][i].y, packed_vertices_import[k][i].z);
+// 	if (0) printf("[%d]i%d updating vertex with global_id %d to %g %g %g \n", rank, iteration, (int)(packed_vertices_import[k][i].glob_id), packed_vertices_import[k][i].x, packed_vertices_import[k][i].y, packed_vertices_import[k][i].z);
       }
       else {
-	printf("[%d]i%d vertex with gid %Zu and pid %d not in map\n",rank,iteration,packed_vertices_import[k][i].glob_id,neighbourProcRecv[k]);  
+         std::cout << "[" << rank << "]i" << iteration
+                   << " vertex with gid " << packed_vertices_import[k][i].glob_id
+                   << " and pid " << neighbourProcRecv[k]
+                   << " not in map" << std::endl ;
       }
     }
   }
@@ -2136,7 +2149,6 @@ int ParallelHelperImpl::comm_smoothed_vtx_b(MsqError& err)
 
   int num;
   int proc;
-  int tag;
   int count;
   int numVtxImport = 0;
   MPI_Status status;
@@ -2156,10 +2168,7 @@ int ParallelHelperImpl::comm_smoothed_vtx_b(MsqError& err)
              &status);          /* info about the received message */
     CHECK_MPI_RZERO( rval, err );
     proc = status.MPI_SOURCE;
-    tag = status.MPI_TAG;
     MPI_Get_count(&status, MPI_INT, &count);
-
-    //    printf("[%d]i%dp%d Receiving %d vertices from proc %d/%d/%d\n",rank,iteration,pass,num,proc,tag,count); fflush(NULL);
 
     /* is there any vertex data to be received */
 
@@ -2186,12 +2195,9 @@ int ParallelHelperImpl::comm_smoothed_vtx_b(MsqError& err)
       CHECK_MPI_RZERO( rval, err );
 
       proc = status.MPI_SOURCE;
-      tag = status.MPI_TAG;
       MPI_Get_count(&status, MPI_DOUBLE_PRECISION, &count);
 
       if (count != 4*num) printf("[%d]i%d WARNING: expected %d vertices = %d bytes from proc %d but only got %d bytes\n",rank,iteration,num,num*4,proc,count); fflush(NULL);
-
-      //      printf("[%d]i%d Received %d vertices from proc %d/%d/%d\n",rank,iteration,num,proc,tag,count); fflush(NULL);
 
       /* update the received vertices in our boundary mesh */
       for (i = 0; i < num; i++) {
@@ -2208,7 +2214,10 @@ int ParallelHelperImpl::comm_smoothed_vtx_b(MsqError& err)
 	  if (0) printf("[%d]i%d updating vertex with global_id %d to %g %g %g \n", rank,iteration, (int)(vertex_pack[i].glob_id), vertex_pack[i].x, vertex_pack[i].y, vertex_pack[i].z);
 	}
 	else {
-	  printf("[%d]i%d vertex with gid %Zu and pid %d not in map\n",rank,iteration,vertex_pack[i].glob_id,proc);
+           std::cout << "[" << rank << "]i" << iteration
+                     << " vertex with gid " << vertex_pack[i].glob_id
+                     << " and pid " << proc
+                     << " not in map" << std::endl;
 	}
       }
     }
@@ -2313,7 +2322,6 @@ int ParallelHelperImpl::comm_smoothed_vtx_b_no_all(MsqError& err)
 
   int num;
   int proc;
-  int tag;
   int count;
   int numVtxImport = 0;
   MPI_Status status;
@@ -2339,10 +2347,7 @@ int ParallelHelperImpl::comm_smoothed_vtx_b_no_all(MsqError& err)
              &status);          /* info about the received message */
     CHECK_MPI_RZERO( rval, err );
     proc = status.MPI_SOURCE;
-    tag = status.MPI_TAG;
     MPI_Get_count(&status, MPI_INT, &count);
-
-    // printf("[%d]i%dp%d Receiving %d vertices from proc %d/%d/%d\n",rank,iteration,pass,num,proc,tag,count); fflush(NULL);
 
     /* is there any vertex data to be received */
 
@@ -2369,12 +2374,9 @@ int ParallelHelperImpl::comm_smoothed_vtx_b_no_all(MsqError& err)
       CHECK_MPI_RZERO( rval, err );
 
       proc = status.MPI_SOURCE;
-      tag = status.MPI_TAG;
       MPI_Get_count(&status, MPI_DOUBLE_PRECISION, &count);
 
       if (count != 4*num) printf("[%d]i%d WARNING: expected %d vertices = %d bytes from proc %d but only got %d bytes\n",rank,iteration,num,num*4,proc,count); fflush(NULL);
-
-      // printf("[%d]i%d Received %d vertices from proc %d/%d/%d\n",rank,iteration,num,proc,tag,count); fflush(NULL);
 
       /* update the received vertices in our boundary mesh */
       for (i = 0; i < num; i++) {
@@ -2391,7 +2393,10 @@ int ParallelHelperImpl::comm_smoothed_vtx_b_no_all(MsqError& err)
 	  if (0 && rank == 1) printf("[%d]i%d updating vertex with global_id %d to %g %g %g \n", rank,iteration, (int)(vertex_pack[i].glob_id), vertex_pack[i].x, vertex_pack[i].y, vertex_pack[i].z);
 	}
 	else {
-	  printf("[%d]i%d vertex with gid %Zu and pid %d not in map\n",rank,iteration,vertex_pack[i].glob_id,proc);
+           std::cout << "[" << rank << "]i" << iteration
+                     << " vertex with gid " << vertex_pack[i].glob_id
+                     << " and pid " << proc
+                     << " not in map" << std::endl ;
 	}
       }
     }

--- a/src/ObjectiveFunction/Mesquite_ObjectiveFunction.cpp
+++ b/src/ObjectiveFunction/Mesquite_ObjectiveFunction.cpp
@@ -186,7 +186,7 @@ bool ObjectiveFunction::evaluate_with_gradient( EvalType eval_type,
   }
   
   ObjectiveFunction* of = this;
-  std::auto_ptr<ObjectiveFunction> deleter;
+  std::shared_ptr<ObjectiveFunction> deleter;
   if (eval_type == CALCULATE) {
     of->clear();
     b = of->evaluate( ACCUMULATE, pd, OF_val, OF_FREE_EVALS_ONLY, err );
@@ -204,7 +204,7 @@ bool ObjectiveFunction::evaluate_with_gradient( EvalType eval_type,
     if (MSQ_CHKERR(err) || !b)
       return false;
     of = this->clone();
-    deleter = std::auto_ptr<ObjectiveFunction>(of);
+    deleter = std::shared_ptr<ObjectiveFunction>(of);
   }
 
     // Determine number of layers of adjacent elements based on metric type.

--- a/src/ObjectiveFunction/Mesquite_ObjectiveFunctionTemplate.cpp
+++ b/src/ObjectiveFunction/Mesquite_ObjectiveFunctionTemplate.cpp
@@ -57,14 +57,14 @@ bool ObjectiveFunctionTemplate::initialize_block_coordinate_descent( MeshDomainA
                                                       PatchSet* ,
                                                       MsqError& err )
 {
-  std::auto_ptr<PatchSet> patch_set;
+  std::shared_ptr<PatchSet> patch_set;
   switch (get_quality_metric()->get_metric_type())
   {
     case QualityMetric::VERTEX_BASED:  
-      patch_set = std::auto_ptr<PatchSet>(new VertexPatches( 1, false ));
+      patch_set = std::shared_ptr<PatchSet>(new VertexPatches( 1, false ));
       break;
     case QualityMetric::ELEMENT_BASED: 
-      patch_set = std::auto_ptr<PatchSet>(new ElementPatches);
+      patch_set = std::shared_ptr<PatchSet>(new ElementPatches);
       break;
     default: 
       MSQ_SETERR(err)("Cannot initialize for BCD for unknown metric type", 

--- a/src/QualityImprover/Mesquite_VertexMover.cpp
+++ b/src/QualityImprover/Mesquite_VertexMover.cpp
@@ -751,8 +751,6 @@ double VertexMover::loop_over_mesh( ParallelMesh* mesh,
         if (one_patch) ++inner_iter;
 
           // Call optimizer - should loop on inner_crit->terminate()
-                size_t num_vert=patch.num_free_vertices();
-                //std::cout << "P[" << get_parallel_rank() << "] tmp srk VertexMover num_vert= " << num_vert << std::endl;
               
         this->optimize_vertex_positions( patch, err );
         if (MSQ_CHKERR(err)) { MSQ_SETERR(perr)("optimize_vertex_positions", MsqError::INVALID_STATE); PERROR_COND; } //goto ERROR;

--- a/src/QualityImprover/OptSolvers/Mesquite_ConjugateGradient.cpp
+++ b/src/QualityImprover/OptSolvers/Mesquite_ConjugateGradient.cpp
@@ -92,9 +92,14 @@ ConjugateGradient::~ConjugateGradient()
 void ConjugateGradient::initialize(PatchData &pd, MsqError &err)
 {
   if (get_parallel_size())
+  {
+     
     MSQ_DBGOUT(2) << "\nP[" << get_parallel_rank() << "] " << "o   Performing Conjugate Gradient optimization.\n";
+  }
   else
+  {
     MSQ_DBGOUT(2) << "\no   Performing Conjugate Gradient optimization.\n";
+  }
   pMemento=pd.create_vertices_memento(err);
 }
 

--- a/src/QualityImprover/OptSolvers/Mesquite_NonGradient.cpp
+++ b/src/QualityImprover/OptSolvers/Mesquite_NonGradient.cpp
@@ -72,8 +72,8 @@ NonGradient::NonGradient(ObjectiveFunction* of)
     mThreshold(0.0),
     mTolerance(0.0),
     mMaxNumEval(0),
-    mNonGradDebug(0),
     mUseExactPenaltyFunction(true),
+    mNonGradDebug(0),
     mScaleDiameter(0.1)
 {
   set_debugging_level(2);
@@ -95,8 +95,8 @@ NonGradient::NonGradient(ObjectiveFunction* of, MsqError &err)
     mThreshold(0.0),
     mTolerance(0.0),
     mMaxNumEval(0),
-    mNonGradDebug(0),
     mUseExactPenaltyFunction(true),
+    mNonGradDebug(0),
     mScaleDiameter(0.1)
 {
   set_debugging_level(2);
@@ -208,7 +208,6 @@ NonGradient::amotry( std::vector<double>& simplex,
                  double psum[], int ihi, double fac, PatchData &pd, MsqError &err)
 {
   int numRow = getDimension();
-  int numCol = numRow + 1;
   std::vector<double> ptry(numRow); // does this make sense?
   double fac1=(1.0-fac)/static_cast<double>(numRow);
   double fac2=fac1-fac;
@@ -255,7 +254,7 @@ void NonGradient::printPatch(const PatchData &pd, MsqError &err)
   MSQ_PRINT(3)("Number of Vertices: %d\n",(int)pd.num_nodes());
 
   std::cout << "Patch " << numNode << "  " << numVert << "  " << numSlaveVert << "  " << numCoin << std::endl;
-  MSQ_PRINT(3)("");
+  MSQ_PRINT(3)(" ");
   std::cout << "Coordinate ";
   std::cout << "         " << std::endl;
   for( size_t index = 0; index < numVert; index++ )
@@ -348,8 +347,8 @@ void NonGradient::initialize_mesh_iteration(PatchData &pd, MsqError &err)
     MSQ_PRINT(3)("minimum edge length %e    maximum edge length %e\n", minEdgeLen,  maxEdgeLen);
   }
 //  setTolerance(ftol);
-  int numRow = dimension;
-  int numCol = numRow+1;  
+  size_t numRow = dimension;
+  size_t numCol = numRow+1;  
   if( numRow*numCol <= simplex.max_size() )
   { 
     simplex.assign(numRow*numCol, 0.);  // guard against previous simplex value
@@ -360,9 +359,9 @@ void NonGradient::initialize_mesh_iteration(PatchData &pd, MsqError &err)
       MSQ_SETERR(err)("Only one free vertex per patch implemented", MsqError::NOT_IMPLEMENTED);
     }
     size_t index = 0;
-    for( int col = 0; col < numCol; col++ )
+    for( size_t col = 0; col < numCol; col++ )
     {
-      for (int row=0;row<numRow;row++)
+      for (size_t row=0;row<numRow;row++)
       {
         simplex[ row + col*numRow ] = coord[index][row];
         if( row == col-1 )
@@ -402,8 +401,6 @@ void NonGradient::optimize_vertex_positions(PatchData &pd,
 
   // standardization
   TerminationCriterion* term_crit=get_inner_termination_criterion();
-  int maxNumEval = getMaxNumEval();
-  double threshold = getThreshold();
 //  double ftol = getTolerance();
   int ilo = 0;  //height[ilo]<=...
   int inhi = 0; //...<=height[inhi]<=

--- a/src/QualityImprover/OptSolvers/Mesquite_QuasiNewton.cpp
+++ b/src/QualityImprover/OptSolvers/Mesquite_QuasiNewton.cpp
@@ -174,7 +174,6 @@ void QuasiNewton::optimize_vertex_positions( PatchData& pd, MsqError& err )
   const double tol1 = 1e-8;
   const double epsilon = 1e-10;
 
-  double norm_r; //, norm_g;
   double alpha, beta;
   double obj, objn;
 
@@ -270,8 +269,6 @@ void QuasiNewton::optimize_vertex_positions( PatchData& pd, MsqError& err )
     v[QNVEC-1].swap( v[0] );
     
     func.update( pd, obj, v[QNVEC], mHess, err ); MSQ_ERRRTN(err);
-    norm_r = length_squared( &(v[QNVEC][0]), nn );
-    //norm_g = sqrt(norm_r);
 
     // checks stopping criterion 
     term.accumulate_patch( pd, err ); MSQ_ERRRTN(err);

--- a/src/QualityMetric/Debug/Mesquite_CompareQM.cpp
+++ b/src/QualityMetric/Debug/Mesquite_CompareQM.cpp
@@ -349,7 +349,9 @@ void CompareQM::check_hess( size_t handle,
                             const std::vector<Matrix3D>& hess2 )
 {
   const size_t n = index_map.size();
+#ifndef NDEBUG // only used for the asserts
   const size_t N = (n + 1) * n / 2;
+  #endif
   assert(n == indices.size());
   assert(N == hess1.size());
   assert(N == hess2.size());

--- a/testSuite/parallel_untangle_shape/par_hex_untangle_shape.cpp
+++ b/testSuite/parallel_untangle_shape/par_hex_untangle_shape.cpp
@@ -381,9 +381,6 @@ public:
 		}
 	      else
 		{
-		  int  msq_debug             = debug; // 1,2,3 for more debug info
-		  bool always_smooth_local   = false;
-
 		  bool do_untangle_only = false;
 		  ParShapeImprover::ParShapeImprovementWrapper siw(innerIter,0.0,gradNorm,100);
 		  siw.m_do_untangle_only = do_untangle_only;


### PR DESCRIPTION
The warning-as-error builds have been complaining
about this one for some time.  The fixes here are
mostly moving from c style output to c++ style and
removing unused variable assignment or putting them
in #ifdef blocks as appropriate.